### PR TITLE
Reallocate EIP when instance is recycled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Don't commit state - big no-no!
+terraform.tfstate*
+.terraform.lock.hcl
+
+# Don't commit private variable values
+terraform.tfvars
+
+# Don't commit provider executables
+.terraform/
+
+# Don't commit key material - also big no-no!
+id_rsa*

--- a/auto-assign-elastic-ip.sh
+++ b/auto-assign-elastic-ip.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Determine instance-id and current region from metadata
+# Retrieve instance ID
+instance_id=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+
+# Retrieve availability zone
+availability_zone=$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone)
+
+# Extract region from availability zone
+# Two $'s here so that terraform templating expands it as is with one $
+region=$${availability_zone::-1}
+
+# If the address is already associated (to a deleted instance), then delete that association.
+# Important to do this, else we will not be able to associate it with new instance launched by ASG.
+association_id=$(aws ec2 describe-addresses --region $region --allocation-ids ${allocation_id} --query 'Addresses[0].AssociationId' --output text)
+if [ "$association_id" != "None" ]
+then
+    echo "Deleting previous EIP association"
+    aws ec2 disassociate-address --region $region --association-id $association_id
+fi
+
+# Associate the address
+echo "Associating EIP"
+aws ec2 associate-address --region $region --instance-id $instance_id --allocation-id ${allocation_id}
+

--- a/test.tf
+++ b/test.tf
@@ -23,7 +23,7 @@ data "aws_ami" "latest_amazon_linux" {
 
 # Allocation of EIP
 resource "aws_eip" "bastion-host" {
-  vpc = true
+  domain = "vpc"
 }
 
 resource "aws_launch_configuration" "bastion" {
@@ -38,7 +38,7 @@ resource "aws_launch_configuration" "bastion" {
   #    Name = var.tagProject
   #  }
 
-  #Connection with privat ssh key
+  #Connection with private ssh key
   connection {
     type        = "ssh"
     user        = "ec2-user"
@@ -50,60 +50,53 @@ resource "aws_launch_configuration" "bastion" {
 }
 
 # 1.Creating an AWS IAM role
-resource "aws_iam_role" "test_role" {
-  name               = "EIP-role"
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
+# Define assume-role policy
+data "aws_iam_policy_document" "assume_role_ec2" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
     }
-  ]
-}
-EOF
-}
-# 2.Creating an IAM policy
-resource "aws_iam_policy" "test_policy" {
-  name   = "test_policy"
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-          "ec2:AssociateAddress", "ec2:DescribeAddresses", "ec2:DescribeTags", "ec2:DescribeInstances"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    }
-  ]
-}
-EOF
+
+    actions = ["sts:AssumeRole"]
+  }
 }
 
-# 3.Attaching the policy to the role
-# The value for the roles parameter has been accessed from the resource block, which we created in step 1.
-#     Explanation:
-#     aws_iam_role is the type of the resource block which we created in step 1.
-#     aws_iam_role.test_role is the name of the variable which we defined.
-#     name is a property of that resource block.
-resource "aws_iam_policy_attachment" "test-attach" {
-  name       = "test-attachment"
-  roles      = ["${aws_iam_role.test_role.name}"]
-  policy_arn = aws_iam_policy.test_policy.arn #                policy_arn = "${aws_iam_policy.policy.arn}"
+# Define role
+# aassume role policy and permissions policy can be done together
+resource "aws_iam_role" "bastion_instance_role" {
+  name               = var.roleName
+  assume_role_policy = data.aws_iam_policy_document.assume_role_ec2.json
+  inline_policy {
+    name = "bastion_policy"
+
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          "Action": [
+              "ec2:AssociateAddress",
+              "ec2:DisassociateAddress",
+              "ec2:DescribeAddresses",
+              "ec2:DescribeTags",
+              "ec2:DescribeInstances"
+          ],
+          Effect   = "Allow"
+          Resource = "*"
+        },
+      ]
+    })
+  }
+  path = "/"
 }
 
-# 4.Creating the IAM instance profile
-# The value for the roles parameter has been accessed from the resource block, which we created in step 1.
+# Instance profile to associate above role with bastion
 resource "aws_iam_instance_profile" "ec2_profile" {
-  name = "bastion_profile"
-  role = aws_iam_role.test_role.name
+  name = "bastion_instance_profile"
+  path = "/"
+  role = aws_iam_role.bastion_instance_role.id
 }
 
 # Auto Scaling Group using 2 Availability zones
@@ -128,26 +121,27 @@ resource "aws_autoscaling_group" "bastion" {
     }
   }
 }
+
 #Creating of Security group
+
+# Gets public IP address of your broadband so the security group can be locked down.
+data "http" "my_ip_address" {
+  url = "http://checkip.amazonaws.com"
+  request_headers = {
+    Accept = "text/plain"
+  }
+}
+
+# Only you have access to the bastion
 resource "aws_security_group" "my_Bastion_host" {
   name        = "Dynamic_security_group"
   description = "Bastion_host_SG"
-
-  dynamic "ingress" {
-    for_each = ["22"]
-    content {
-      from_port   = ingress.value
-      to_port     = ingress.value
-      protocol    = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
-    }
-  }
 
   ingress {
     from_port   = 22
     to_port     = 22
     protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = ["${chomp(data.http.my_ip_address.response_body)}/32"]
   }
   egress {
     from_port   = 0
@@ -167,4 +161,9 @@ resource "aws_default_subnet" "default_az1" {
 
 resource "aws_default_subnet" "default_az2" {
   availability_zone = data.aws_availability_zones.available.names[1]
+}
+
+output "eip-address" {
+    description = "Public IP address of bastion (EIP)"
+    value = aws_eip.bastion-host.address
 }

--- a/variabiables.tf
+++ b/variabiables.tf
@@ -9,3 +9,6 @@ variable "tagOwner" {}
 variable "tagProject" {}
 variable "awsAccessKey" {}
 variable "awsSecretKey" {}
+variable "roleName" {
+  default = "bastion-role"
+}


### PR DESCRIPTION
* Added missing file `auto-assign-elastic-ip.sh` and put code in it to allocate/re-allocate EIP
* Tidied up instance role and profile
* Locked down bastion security group. Very bad practice to allow ingress from `0.0.0.0/0` as bad actors will find it and attempt to attack.

Now if you deploy this, you will be able to connect to the bastion instance via the EIP address. If you terminate the instance and let the ASG create a new one, then this new instance will take ownership of the EIP.

Beware that SSH will detect that the machine you accepted as a known host has changed after the new instance is created and will probably refuse to connect. To fix that you need to delete any previous entry for the EIP address from your `known_hosts` file.